### PR TITLE
feat: discord webhook(#8)

### DIFF
--- a/simvex/src/main/java/dochigosum/simvex/SimvexApplication.java
+++ b/simvex/src/main/java/dochigosum/simvex/SimvexApplication.java
@@ -3,7 +3,6 @@ package dochigosum.simvex;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableFeignClients

--- a/simvex/src/main/java/dochigosum/simvex/SimvexApplication.java
+++ b/simvex/src/main/java/dochigosum/simvex/SimvexApplication.java
@@ -3,6 +3,7 @@ package dochigosum.simvex;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableFeignClients

--- a/simvex/src/main/java/dochigosum/simvex/global/config/AsyncConfig.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package dochigosum.simvex.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "discordAsyncExecutor")
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("DiscordAsync-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/DiscordWebhookClient.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/DiscordWebhookClient.java
@@ -1,0 +1,15 @@
+package dochigosum.simvex.global.feignclient.webhook;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+        name = "discordWebhookClient",
+        url = "${discord.webhook.url}"
+)
+public interface DiscordWebhookClient {
+
+    @PostMapping
+    void send(@RequestBody DiscordWebhookRequest request);
+}

--- a/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/DiscordWebhookRequest.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/DiscordWebhookRequest.java
@@ -1,0 +1,4 @@
+package dochigosum.simvex.global.feignclient.webhook;
+
+public record DiscordWebhookRequest(String content) {
+}

--- a/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/SendService.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/SendService.java
@@ -3,6 +3,7 @@ package dochigosum.simvex.global.feignclient.webhook;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,6 +13,7 @@ public class SendService {
 
     private final DiscordWebhookClient discordWebhookClient;
 
+    @Async // 비동기처리
     public void sendDiscordAlert(Exception e, HttpServletRequest request) {
         try {
             String message = buildMessage(e, request);
@@ -35,11 +37,7 @@ public class SendService {
         if (errorMessage.length() > 2000) {
             return errorMessage.substring(0, 1990) + "\n... (중략)";
         }
-        return """
-            ## Internal Server Error
-            - Method: `%s`
-            - URI: `%s`
-            - %s
-            """.formatted(request.getMethod(), request.getRequestURI(), e.getMessage());
+
+        return errorMessage;
     }
 }

--- a/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/SendService.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/SendService.java
@@ -1,6 +1,5 @@
 package dochigosum.simvex.global.feignclient.webhook;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -13,10 +12,10 @@ public class SendService {
 
     private final DiscordWebhookClient discordWebhookClient;
 
-    @Async // 비동기처리
-    public void sendDiscordAlert(Exception e, HttpServletRequest request) {
+    @Async("discordAsyncExecutor") // 비동기처리
+    public void sendDiscordAlert(Exception e, String method, String uri) {
         try {
-            String message = buildMessage(e, request);
+            String message = buildMessage(e, method, uri);
             discordWebhookClient.send(
                     new DiscordWebhookRequest(message)
             );
@@ -25,13 +24,13 @@ public class SendService {
         }
     }
 
-    public String buildMessage(Exception e, HttpServletRequest request) {
+    public String buildMessage(Exception e, String method, String uri) {
         String errorMessage = """
             ## Internal Server Error
             - Method: `%s`
             - URI: `%s`
             - %s
-            """.formatted(request.getMethod(), request.getRequestURI(), e.getMessage());
+            """.formatted(method, uri, e.getMessage());
 
         // 2000자 이상이면 자름
         if (errorMessage.length() > 2000) {

--- a/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/SendService.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/feignclient/webhook/SendService.java
@@ -1,0 +1,45 @@
+package dochigosum.simvex.global.feignclient.webhook;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SendService {
+
+    private final DiscordWebhookClient discordWebhookClient;
+
+    public void sendDiscordAlert(Exception e, HttpServletRequest request) {
+        try {
+            String message = buildMessage(e, request);
+            discordWebhookClient.send(
+                    new DiscordWebhookRequest(message)
+            );
+        } catch (Exception ex) {
+            log.error("Failed to send discord webhook", ex);
+        }
+    }
+
+    public String buildMessage(Exception e, HttpServletRequest request) {
+        String errorMessage = """
+            ## Internal Server Error
+            - Method: `%s`
+            - URI: `%s`
+            - %s
+            """.formatted(request.getMethod(), request.getRequestURI(), e.getMessage());
+
+        // 2000자 이상이면 자름
+        if (errorMessage.length() > 2000) {
+            return errorMessage.substring(0, 1990) + "\n... (중략)";
+        }
+        return """
+            ## Internal Server Error
+            - Method: `%s`
+            - URI: `%s`
+            - %s
+            """.formatted(request.getMethod(), request.getRequestURI(), e.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- 디스코드 웹훅을 연동하였습니다.

## Related Issue
- Closes #8

## Scope
- 포함 범위: feignclient/webhook

## Implementation
- SendService를 임포트하여 핸들러 등에서 사용합니다.

## Testing
- [ ] 단위 테스트
- [ ] 통합 테스트
- [ ] 수동 검증

## Deployment Notes
*no response*

## Checklist
- [ ] 제품 및 기술 요구사항 충족
- [ ] 하위 호환성 고려 완료
- [ ] 해당 시 문서 업데이트 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Discord 웹훅을 통한 자동 알림 전송 기능이 추가되었습니다.
  * 오류 발생 시 요청 방식, 요청 경로, 오류 내용이 포함된 형식으로 알림이 전송됩니다.
  * Discord 메시지 길이 제한을 초과하면 자동으로 단축하여 전송합니다.
  * 알림 전송은 비동기로 처리되며, 전송 실패 시 내부 로그에 기록됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->