### PR TITLE
feat: Redis 설정 추가 및 RedisConfig 추가 #18

### DIFF
--- a/simvex/build.gradle
+++ b/simvex/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/simvex/src/main/java/dochigosum/simvex/global/config/RedisConfig.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package dochigosum.simvex.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/simvex/src/main/resources/application.properties
+++ b/simvex/src/main/resources/application.properties
@@ -12,6 +12,11 @@ spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${
 spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${PASSWORD}
 
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.data.redis.lettuce.pool.max-active=8
+spring.data.redis.lettuce.pool.max-idle=8
+
 jwt.secret=${JWT_SECRET}
 jwt.access-token-expiration=${JWT_ACCESS_EXPIRATION}
 


### PR DESCRIPTION
* **Gradle 환경 설정**: 시스템 내 Gradle 환경 변수 등록 및 버전(8.x) 확인
* **Redis 인프라 설정**: application.properties에 호스트, 포트 및 커넥션 풀(max-active, max-idle) 옵션 추가
* **RedisConfig 구현**: LettuceConnectionFactory를 이용한 Redis 연결 빈(Bean) 등록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* Redis 통합 지원이 추가되었습니다. 애플리케이션은 이제 Redis를 활용하여 높은 성능의 데이터 캐싱 기능을 제공합니다. 필요한 라이브러리와 기본 구성 설정이 모두 자동으로 포함되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->