### PR TITLE
feat: redis 설정 추가 및 RedisConfig 추가 #18

### DIFF
--- a/simvex/build.gradle
+++ b/simvex/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/simvex/src/main/java/dochigosum/simvex/global/config/RedisConfig.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package dochigosum.simvex.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/simvex/src/main/resources/application.properties
+++ b/simvex/src/main/resources/application.properties
@@ -12,6 +12,11 @@ spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${
 spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${PASSWORD}
 
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.data.redis.lettuce.pool.max-active=8
+spring.data.redis.lettuce.pool.max-idle=8
+
 jwt.secret=${JWT_SECRET}
 jwt.access-token-expiration=${JWT_ACCESS_EXPIRATION}
 


### PR DESCRIPTION
* **Gradle 환경 변수 설정**: 터미널 어디서든 gradle 명령어를 사용할 수 있도록 시스템 환경 변수(Windows/macOS) 설정을 완료하고 가이드를 정리했습니다.

* **Redis 설정 추가**: application.properties에 Redis 호스트, 포트 설정을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * Redis 캐싱 및 데이터 저장소 지원이 추가되었습니다. Redis 연결이 설정되어 애플리케이션의 성능과 데이터 처리 능력이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->