### PR TITLE
feature:  전역 에러 처리 표준 도입(#31)

### DIFF
--- a/simvex/src/main/java/dochigosum/simvex/global/error/ErrorCode.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/error/ErrorCode.java
@@ -1,0 +1,13 @@
+package dochigosum.simvex.global.error;
+
+import org.springframework.http.HttpStatus;
+
+// 모든 커스텀 에러 코드는 이 인터페이스를 구현해서 사용합니다.
+public interface ErrorCode {
+
+    HttpStatus getStatus();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/simvex/src/main/java/dochigosum/simvex/global/error/ErrorResponse.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/error/ErrorResponse.java
@@ -1,0 +1,32 @@
+package dochigosum.simvex.global.error;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorResponse(
+        Instant timestamp,
+        int status,
+        String error,
+        String code,
+        String message,
+        String path
+) {
+
+    public static ErrorResponse of(HttpStatus status, String code, String message, String path) {
+        return new ErrorResponse(
+                Instant.now(),
+                status.value(),
+                status.getReasonPhrase(),
+                code,
+                message,
+                path
+        );
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String path) {
+        return of(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage(), path);
+    }
+}

--- a/simvex/src/main/java/dochigosum/simvex/global/error/GlobalErrorCode.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/error/GlobalErrorCode.java
@@ -1,0 +1,47 @@
+package dochigosum.simvex.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public enum GlobalErrorCode implements ErrorCode {
+
+    // 400
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "GLB_400", "잘못된 요청입니다."),
+
+    // 401/403
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "GLB_401", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "GLB_403", "권한이 없습니다."),
+
+    // 404
+    NOT_FOUND(HttpStatus.NOT_FOUND, "GLB_404", "리소스를 찾을 수 없습니다."),
+
+    // 409
+    CONFLICT(HttpStatus.CONFLICT, "GLB_409", "요청이 충돌했습니다."),
+
+    // 500
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLB_500", "서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    GlobalErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/simvex/src/main/java/dochigosum/simvex/global/error/exception/SimvexException.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/error/exception/SimvexException.java
@@ -1,0 +1,23 @@
+package dochigosum.simvex.global.error.exception;
+
+import dochigosum.simvex.global.error.ErrorCode;
+
+// 서비스 전반에서 사용하는 커스텀 예외의 베이스 클래스
+public class SimvexException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public SimvexException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public SimvexException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/simvex/src/main/java/dochigosum/simvex/global/error/handler/GlobalExceptionHandler.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/error/handler/GlobalExceptionHandler.java
@@ -26,9 +26,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(SimvexException.class)
     public ResponseEntity<ErrorResponse> handleSimvexException(SimvexException e, HttpServletRequest request) {
         var ec = e.getErrorCode();
+        String message = e.getMessage() != null ? e.getMessage() : ec.getMessage();
+
         return ResponseEntity
                 .status(ec.getStatus())
-                .body(ErrorResponse.of(ec, request.getRequestURI()));
+                .body(ErrorResponse.of(ec.getStatus(), ec.getCode(), message, request.getRequestURI()));
     }
 
     // @Valid 바인딩 실패 (validation starter를 추가했을 때 동작)

--- a/simvex/src/main/java/dochigosum/simvex/global/error/handler/GlobalExceptionHandler.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/error/handler/GlobalExceptionHandler.java
@@ -1,0 +1,83 @@
+package dochigosum.simvex.global.error.handler;
+
+import dochigosum.simvex.global.error.ErrorResponse;
+import dochigosum.simvex.global.error.GlobalErrorCode;
+import dochigosum.simvex.global.error.exception.SimvexException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(SimvexException.class)
+    public ResponseEntity<ErrorResponse> handleSimvexException(SimvexException e, HttpServletRequest request) {
+        var ec = e.getErrorCode();
+        return ResponseEntity
+                .status(ec.getStatus())
+                .body(ErrorResponse.of(ec, request.getRequestURI()));
+    }
+
+    // @Valid 바인딩 실패 (validation starter를 추가했을 때 동작)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpServletRequest request) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + (fe.getDefaultMessage() == null ? "invalid" : fe.getDefaultMessage()))
+                .collect(Collectors.joining(", "));
+
+        return ResponseEntity
+                .status(GlobalErrorCode.INVALID_REQUEST.getStatus())
+                .body(ErrorResponse.of(GlobalErrorCode.INVALID_REQUEST.getStatus(), GlobalErrorCode.INVALID_REQUEST.getCode(), message, request.getRequestURI()));
+    }
+
+    @ExceptionHandler({
+            IllegalArgumentException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class,
+            HttpMessageNotReadableException.class,
+            HttpRequestMethodNotSupportedException.class,
+            HttpMediaTypeNotSupportedException.class
+    })
+    public ResponseEntity<ErrorResponse> handleBadRequest(Exception e, HttpServletRequest request) {
+        return ResponseEntity
+                .status(GlobalErrorCode.INVALID_REQUEST.getStatus())
+                .body(ErrorResponse.of(GlobalErrorCode.INVALID_REQUEST.getStatus(), GlobalErrorCode.INVALID_REQUEST.getCode(), GlobalErrorCode.INVALID_REQUEST.getMessage(), request.getRequestURI()));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException e, HttpServletRequest request) {
+        return ResponseEntity
+                .status(GlobalErrorCode.UNAUTHORIZED.getStatus())
+                .body(ErrorResponse.of(GlobalErrorCode.UNAUTHORIZED, request.getRequestURI()));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException e, HttpServletRequest request) {
+        return ResponseEntity
+                .status(GlobalErrorCode.FORBIDDEN.getStatus())
+                .body(ErrorResponse.of(GlobalErrorCode.FORBIDDEN, request.getRequestURI()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception e, HttpServletRequest request) {
+        // 서버 로그에만 스택 트레이스 남기고, 응답은 안전하게
+        log.error("Unexpected exception: {} {}", request.getMethod(), request.getRequestURI(), e);
+
+        return ResponseEntity
+                .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ErrorResponse.of(GlobalErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI()));
+    }
+}

--- a/simvex/src/main/java/dochigosum/simvex/global/error/handler/GlobalExceptionHandler.java
+++ b/simvex/src/main/java/dochigosum/simvex/global/error/handler/GlobalExceptionHandler.java
@@ -16,12 +16,13 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(SimvexException.class)
     public ResponseEntity<ErrorResponse> handleSimvexException(SimvexException e, HttpServletRequest request) {


### PR DESCRIPTION
## Summary

* 전역 에러 처리 표준을 도입했습니다.
* `ErrorCode` 인터페이스와 `GlobalErrorCode(GLB_400/401/403/404/409/500)`를 추가해 에러 코드를 일관되게 관리합니다.
* 공통 에러 응답 포맷(`ErrorResponse`)을 정의했습니다.
* 커스텀 예외 베이스(`SimvexException`) 및 전역 예외 핸들러(`GlobalExceptionHandler`)를 구현했습니다.

## Related Issue

* Closes #31 

## Root Cause

* 기존에는 예외 발생 시 응답 포맷/상태코드가 케이스마다 달라 클라이언트가 에러 처리를 일관되게 할 수 없었습니다.
* Spring 기본 예외(파라미터 검증, 형변환, 바디 파싱, Security 인증/인가 등)와 도메인 예외가 섞여 응답 규칙이 명확하지 않았습니다.

## Fix Description

* No response

## Testing

* No response

## Risk & Impact

* No response

## Checklist

* No response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 일관된 API 오류 응답 도입: 타임스탬프, HTTP 상태, 에러 이름, 코드, 메시지, 요청 경로 포함.
  * 공통 오류 코드 집합과 한국어 메시지 제공으로 클라이언트가 오류 원인 파악 용이.
  * 사용자 정의 예외를 통해 오류 코드와 메시지가 응답에 반영됨.

* **리팩토링**
  * 전역 예외 처리 도입으로 유효성 검사 실패, 인증/권한 오류 및 기타 예외를 적절한 HTTP 상태와 표준 페이로드로 통합 응답.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->